### PR TITLE
Pass $mode into the has/doesn't have query builder methods

### DIFF
--- a/src/Jedrzej/Searchable/Constraint.php
+++ b/src/Jedrzej/Searchable/Constraint.php
@@ -84,11 +84,11 @@ class Constraint
         if ($this->isRelation($field)) {
             list($relation, $field) = $this->splitRelationField($field);
             if (static::parseIsNegation($relation)) {
-                $builder->whereDoesntHave($relation, function (Builder $builder) use ($field, $mode) {
+                $builder->doesntHave($relation, $mode, function (Builder $builder) use ($field, $mode) {
                     $this->doApply($builder, $field, $mode);
                 });
             } else {
-                $builder->whereHas($relation, function (Builder $builder) use ($field, $mode) {
+                $builder->has($relation, '>=', 1, $mode, function (Builder $builder) use ($field, $mode) {
                     $this->doApply($builder, $field, $mode);
                 });
             }


### PR DESCRIPTION
This pull request changes the builder method calls to account for the $mode parameter.

`->whereDoesntHave()` uses `->doesntHave()` under the hood (https://github.com/laravel/framework/blob/5.1/src/Illuminate/Database/Eloquent/Builder.php#L722) which allows passing an "or" or "and" value.  Laravel calls this the 'operator'. This package calls this the 'mode'. 

`->whereHas()` uses `->has()` under the hood (https://github.com/laravel/framework/blob/5.1/src/Illuminate/Database/Eloquent/Builder.php#L710) which allows passing the operator/mode.  

The intended behavior when passing ?mode=or is that ALL filters are applied in DISJUNCTION.  Currently, the behavior is using mode=or for parameters that exist on the model and mode=and for relation parameters which is unintended.