### PR TITLE
Feature/allow separate and parameters & Fix Relation with Or

### DIFF
--- a/src/Jedrzej/Searchable/Constraint.php
+++ b/src/Jedrzej/Searchable/Constraint.php
@@ -85,11 +85,11 @@ class Constraint
             list($relation, $field) = $this->splitRelationField($field);
             if (static::parseIsNegation($relation)) {
                 $builder->doesntHave($relation, $mode, function (Builder $builder) use ($field, $mode) {
-                    $this->doApply($builder, $field, $mode);
+                    $this->doApply($builder, $field, $mode, true);
                 });
             } else {
                 $builder->has($relation,'>=',1,$mode, function (Builder $builder) use ($field, $mode) {
-                    $this->doApply($builder, $field, $mode);
+                    $this->doApply($builder, $field, $mode, true);
                 });
             }
         } else {
@@ -128,7 +128,7 @@ class Constraint
      * @param string $field field name
      * @param string $mode determines how constraint is added to existing query ("or" or "and")
      */
-    protected function doApply(Builder $builder, $field, $mode = Constraint::MODE_AND)
+    protected function doApply(Builder $builder, $field, $mode = Constraint::MODE_AND, $relation = false)
     {
         if ($this->operator == Constraint::OPERATOR_IN) {
             $method = $mode != static::MODE_OR ? 'whereIn' : 'orWhereIn';
@@ -143,8 +143,12 @@ class Constraint
             $method = $mode != static::MODE_OR ? 'whereNull' : 'orWhereNull';
             $builder->$method($field);
         } else {
-            $method = $mode != static::MODE_OR ? 'where' : 'orWhere';
-            $builder->$method($field, $this->operator, $this->value);
+            if ($relation === true) {
+                $builder->where($field, $this->operator, $this->value);
+            } else {
+                $method = $mode != static::MODE_OR ? 'where' : 'orWhere';
+                $builder->$method($field, $this->operator, $this->value);
+            }
         }
     }
 

--- a/src/Jedrzej/Searchable/Constraint.php
+++ b/src/Jedrzej/Searchable/Constraint.php
@@ -84,11 +84,11 @@ class Constraint
         if ($this->isRelation($field)) {
             list($relation, $field) = $this->splitRelationField($field);
             if (static::parseIsNegation($relation)) {
-                $builder->whereDoesntHave($relation, function (Builder $builder) use ($field, $mode) {
+                $builder->doesntHave($relation, $mode, function (Builder $builder) use ($field, $mode) {
                     $this->doApply($builder, $field, $mode);
                 });
             } else {
-                $builder->whereHas($relation, function (Builder $builder) use ($field, $mode) {
+                $builder->has($relation,'>=',1,$mode, function (Builder $builder) use ($field, $mode) {
                     $this->doApply($builder, $field, $mode);
                 });
             }

--- a/src/Jedrzej/Searchable/Constraint.php
+++ b/src/Jedrzej/Searchable/Constraint.php
@@ -85,11 +85,11 @@ class Constraint
             list($relation, $field) = $this->splitRelationField($field);
             if (static::parseIsNegation($relation)) {
                 $builder->doesntHave($relation, $mode, function (Builder $builder) use ($field, $mode) {
-                    $this->doApply($builder, $field, $mode, true);
+                    $this->doApplyRelation($builder, $field, $mode);
                 });
             } else {
                 $builder->has($relation,'>=',1,$mode, function (Builder $builder) use ($field, $mode) {
-                    $this->doApply($builder, $field, $mode, true);
+                    $this->doApplyRelation($builder, $field, $mode);
                 });
             }
         } else {
@@ -128,7 +128,7 @@ class Constraint
      * @param string $field field name
      * @param string $mode determines how constraint is added to existing query ("or" or "and")
      */
-    protected function doApply(Builder $builder, $field, $mode = Constraint::MODE_AND, $relation = false)
+    protected function doApply(Builder $builder, $field, $mode = Constraint::MODE_AND)
     {
         if ($this->operator == Constraint::OPERATOR_IN) {
             $method = $mode != static::MODE_OR ? 'whereIn' : 'orWhereIn';
@@ -149,6 +149,33 @@ class Constraint
                 $method = $mode != static::MODE_OR ? 'where' : 'orWhere';
                 $builder->$method($field, $this->operator, $this->value);
             }
+        }
+    }
+
+    /**
+     * Applies non-relation constraint to query.
+     *
+     * @param Builder $builder query builder
+     * @param string $field field name
+     * @param string $mode determines how constraint is added to existing query ("or" or "and")
+     */
+    protected function doApplyRelation(Builder $builder, $field, $mode = Constraint::MODE_AND)
+    {
+        if ($this->operator == Constraint::OPERATOR_IN) {
+            $method = 'whereIn';
+            $builder->$method($field, $this->value);
+        } elseif ($this->operator == Constraint::OPERATOR_NOT_IN) {
+            $method = 'whereNotIn';
+            $builder->$method($field, $this->value);
+        } elseif ($this->operator == Constraint::OPERATOR_NOT_NULL) {
+            $method = 'whereNotNull';
+            $builder->$method($field);
+        } elseif ($this->operator == Constraint::OPERATOR_NULL) {
+            $method = 'whereNull';
+            $builder->$method($field);
+        } else {
+            $method = 'where';
+            $builder->$method($field, $this->operator, $this->value);
         }
     }
 

--- a/src/Jedrzej/Searchable/Constraint.php
+++ b/src/Jedrzej/Searchable/Constraint.php
@@ -143,12 +143,8 @@ class Constraint
             $method = $mode != static::MODE_OR ? 'whereNull' : 'orWhereNull';
             $builder->$method($field);
         } else {
-            if ($relation === true) {
-                $builder->where($field, $this->operator, $this->value);
-            } else {
-                $method = $mode != static::MODE_OR ? 'where' : 'orWhere';
-                $builder->$method($field, $this->operator, $this->value);
-            }
+            $method = $mode != static::MODE_OR ? 'where' : 'orWhere';
+            $builder->$method($field, $this->operator, $this->value);
         }
     }
 

--- a/src/Jedrzej/Searchable/SearchableTrait.php
+++ b/src/Jedrzej/Searchable/SearchableTrait.php
@@ -46,11 +46,9 @@ trait SearchableTrait
         }
 
         foreach ($queries as $mode => $newQuery) {
-            logger()->debug("$mode", [$newQuery]);
-
             // We need to throw the filtered stuff out here, too.
             $query = $this->filterNonSearchableParameters($newQuery);
-            $constraints = $this->getConstraints($builder, $newQuery);
+            $constraints = $this->getConstraints($builder, $query);
 
             // The mode translates to an `where` group and a `orWhere` group.
             $method = $mode !== 'or' ? 'where' : 'orWhere';

--- a/src/Jedrzej/Searchable/SearchableTrait.php
+++ b/src/Jedrzej/Searchable/SearchableTrait.php
@@ -22,6 +22,8 @@ trait SearchableTrait
     {
         $query = (array)($query ?: Input::all());
 
+        logger()->debug('Query Params', [request(), $query]);
+
         $mode = $this->getQueryMode($query);
         $query = $this->filterNonSearchableParameters($query);
         $constraints = $this->getConstraints($builder, $query);

--- a/src/Jedrzej/Searchable/SearchableTrait.php
+++ b/src/Jedrzej/Searchable/SearchableTrait.php
@@ -90,19 +90,20 @@ trait SearchableTrait
     /**
      * Calls constraint interceptor on model.
      *
-     * @param Builder    $builder    query builder
-     * @param string     $field      field on which constraint is applied
+     * @param Builder    $builder query builder
+     * @param string     $field field on which constraint is applied
      * @param Constraint $constraint constraint
+     * @param string     $mode The mode.
      *
      * @return bool true if constraint was intercepted by model's method
      */
-    protected function callInterceptor(Builder $builder, $field, Constraint $constraint)
+    protected function callInterceptor(Builder $builder, $field, Constraint $constraint, $mode = Constraint::MODE_AND)
     {
         $model = $builder->getModel();
         $interceptor = sprintf('process%sFilter', str_replace(':', '_', Str::studly($field)));
 
         if (method_exists($model, $interceptor)) {
-            if ($model->$interceptor($builder, $constraint)) {
+            if ($model->$interceptor($builder, $constraint, $mode)) {
                 return true;
             }
         }
@@ -141,7 +142,7 @@ trait SearchableTrait
     protected function applyConstraint(Builder $builder, $field, $constraint, $mode = Constraint::MODE_AND)
     {
         // let model handle the constraint if it has the interceptor
-        if (!$this->callInterceptor($builder, $field, $constraint)) {
+        if (!$this->callInterceptor($builder, $field, $constraint, $mode)) {
             $constraint->apply($builder, $field, $mode);
         }
     }

--- a/src/Jedrzej/Searchable/SearchableTrait.php
+++ b/src/Jedrzej/Searchable/SearchableTrait.php
@@ -50,8 +50,8 @@ trait SearchableTrait
             $query = $this->filterNonSearchableParameters($newQuery);
             $constraints = $this->getConstraints($builder, $query);
 
-            // The mode translates to an `where` group and a `orWhere` group.
-            $method = $mode !== 'or' ? 'where' : 'orWhere';
+            // Always group the stupid things!
+            $method = 'where';
             $builder->$method(function ($query) use ($constraints, $mode) {
                 $this->applyConstraints($query, $constraints, $mode);
             });


### PR DESCRIPTION

There are no tests for this (but it does work) and this PR is more for discussion.

This address issue #42 by allowing users to append `__and` and `__or`; all the `__and` will group together and the `__or`s are self explanatory. So you can do:

* url?columnOne__and=1&columnTwo__and&columnThree__or

It also fixes #38 which is a duplicate of PR #39 but I'm not sure #39 works.
